### PR TITLE
Add zipped build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,15 @@ Yes, you can!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+
+## How do I generate a zipped static build?
+
+Run the following command to compile the React application to plain HTML, CSS and JavaScript files in `dist` and create a `dist.zip` archive containing the static website:
+
+```sh
+npm run build:zip
+```
+
+This produces `dist.zip` which you can unzip on any server to host the site.
+
+

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "build:zip": "vite build && zip -r dist.zip dist"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",


### PR DESCRIPTION
## Summary
- add `build:zip` script that compiles the app and creates a zip archive
- document how to create the zipped static build

## Testing
- `npm run build:zip`

------
https://chatgpt.com/codex/tasks/task_e_6884c7171aa8832d89c391243e174c7f